### PR TITLE
Add Cannabis context tags

### DIFF
--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Blue Dream/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Blue Dream/object.json
@@ -40,4 +40,11 @@
         // "tr": "",
         // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Cannabis/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Cannabis/object.json
@@ -42,4 +42,12 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_spring",
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Girl Scout Cookies/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Girl Scout Cookies/object.json
@@ -40,4 +40,11 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Green Crack/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Green Crack/object.json
@@ -40,4 +40,11 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Hemp/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Hemp/object.json
@@ -40,4 +40,12 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_spring",
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Hybrid/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Hybrid/object.json
@@ -40,4 +40,11 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Indica/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Indica/object.json
@@ -40,4 +40,10 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Northern Lights/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Northern Lights/object.json
@@ -40,4 +40,10 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/OG Kush/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/OG Kush/object.json
@@ -40,4 +40,11 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Sativa/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Sativa/object.json
@@ -40,4 +40,10 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Sour Diesel/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Sour Diesel/object.json
@@ -40,4 +40,10 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Strawberry Cough/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Strawberry Cough/object.json
@@ -40,4 +40,11 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Tobacco/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/Tobacco/object.json
@@ -34,4 +34,8 @@
          // "tr": "",
          // "zh": "",
     }
+    "ContextTags": [
+        "season_spring",
+        "season_summer"
+    ]
 }

--- a/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/White Widow/object.json
+++ b/[PPJA] Cannabis Kit/[JA] Cannabis Kit/Objects/White Widow/object.json
@@ -40,4 +40,11 @@
         // "tr": "",
         // "zh": "",
     }
+    "ContextTags": [
+        "season_summer",
+        "season_fall",
+        "flower_item",
+        "flower_cannabinoid",
+        "trellis_item"
+    ]
 }


### PR DESCRIPTION
Add context tags to PPJA/[PPJA] Cannabis Kit/[JA] Cannabis Kit.

I noticed the recently added [PFM] Cannabis Kit/ProducerRules.json references "flower_cannabinoid" in all the InputIdentifier fields, but that no objects are tagged with flower_cannabinoid. So I added what I believe to be the correct tags. Then I got carried away and added season flower_item and trellis_item to that tags as well.