### PR TITLE
Ancient Crops: revert i18n default change

### DIFF
--- a/[PPJA] Ancient Crops/[PFM] Ancient Crops/i18n/default.json
+++ b/[PPJA] Ancient Crops/[PFM] Ancient Crops/i18n/default.json
@@ -1,3 +1,3 @@
 {   
-    "Grinder.Herb": "{inputName} Moído(a)",
+    "Grinder.Herb": "Ground {inputName}",
 }


### PR DESCRIPTION
The mail rewrite in d51229c880399935d4d46bd75f23a1425435fc5d changed the default (en) translation, which results in the following SMAPI error. This reverts that change.

`[Producer Framework Mod] The custom name 'Ground {inputName}' is already in use for the object with the index '2363'. The custom name '{inputName} Moído(a)' will be ignored.`