### PR TITLE
Fall back to standard Kombucha value in Glass Jar rules

### DIFF
--- a/[PPJA] Artisan Valley/[PFM] Artisan Valley/ProducerRules.json
+++ b/[PPJA] Artisan Valley/[PFM] Artisan Valley/ProducerRules.json
@@ -426,9 +426,6 @@
         "InputStack": 1,
         "MinutesUntilReady": 1600,
         "OutputIdentifier": "Kombucha",
-        "InputPriceBased": true,
-        "OutputPriceIncrement": 200,
-        "OutputPriceMultiplier": 2.5,
         "Sounds": ["Ship"],
     },
     {


### PR DESCRIPTION
Kombucha is currently only made from Common Mushroom, doesn't have variable input so probably shouldn't have variable-value output. This change should make game behavior match with Mouseypounds documentation, which puts value at 150. I'm currently seeing 420 in-game. 

In 2804ea1bd77f162548252989473a1e6a1dd605bc the other Glass Jar rules were updated to use static output value and this one was handled differently. Could be that this is set as it is due to ongoing development of more fancy Kombucha mechanics, let me know if the doc discrepancy should be fixed a different way.