### PR TITLE
Sweet Potato name change

### DIFF
--- a/[PPJA] Fruits and Veggies/[JA] Fruits and Veggies/Crops/Sweet Potato/crop.json
+++ b/[PPJA] Fruits and Veggies/[JA] Fruits and Veggies/Crops/Sweet Potato/crop.json
@@ -26,7 +26,7 @@
     "fr": "Tubercule de patate douce",
     "hu": "Édesburgonya magvak",
     // "it": "",
-    "ja": "サツマイモのタネ",
+    "ja": "スイートポテトのタネ",
     "pt": "Sementes de batata doce",
     "ru": "Семена сладкого картофеля",
     "tr": "Tatlı Patates Tohumu",


### PR DESCRIPTION
The current Japanese translation overlaps with Yam in vanilla.