### PR TITLE
Sweet Potato name change

### DIFF
--- a/[PPJA] Fruits and Veggies/[JA] Fruits and Veggies/Objects/Sweet Potato/object.json
+++ b/[PPJA] Fruits and Veggies/[JA] Fruits and Veggies/Objects/Sweet Potato/object.json
@@ -19,7 +19,7 @@
     "fr": "Patate douce",
     "hu": "Édesburgonya",
     // "it": "",
-    "ja": "サツマイモ",
+    "ja": "スイートポテト",
     "pt": "Batata doce",
     "ru": "Сладкий картофель",
     "tr": "Tatlı Patates",


### PR DESCRIPTION
The current Japanese translation overlaps with Yam in vanilla.