### PR TITLE
Quick typo fix for Coal Root and Money Plant

### DIFF
--- a/[JA] Fantasy Crops/Crops/Coal Root/crop.json
+++ b/[JA] Fantasy Crops/Crops/Coal Root/crop.json
@@ -2,7 +2,7 @@
     "Name": "Coal Root",
     "Product": 382,
     "SeedName": "Coal Seeds",
-    "SeedDescription": "Plant these in spring or summer. Takes 10 days to mature.",
+    "SeedDescription": "Plant these in spring or summer. Takes 8 days to mature.",
     "Type": "ArtisanGoods",
 
     "Seasons": ["spring", "summer"],

--- a/[JA] Fantasy Crops/Crops/Money Plant/crop.json
+++ b/[JA] Fantasy Crops/Crops/Money Plant/crop.json
@@ -2,7 +2,7 @@
     "Name": "Money Plant",
     "Product": "Doubloon",
     "SeedName": "Doubloon Seeds",
-    "SeedDescription": "Plant these in fall. Takes 13 days to mature, and keeps producing after the first harvest.",
+    "SeedDescription": "Plant these in fall. Takes 10 days to mature, and keeps producing after the first harvest.",
     "Type": "ArtisanGoods",
 
     "Seasons": ["fall"],


### PR DESCRIPTION
Hi! I noticed that there were two typos in the files, specifically the growth times for the Coal Root and the Money Plant. Coal Root, according to the numbers given, should take 8 days to grow, but it is listed as 10. Money Plant should be 10 with a 3 day regrowth period, but it is listed as 13. I simply fixed these numbers. This is my first time submitting a PR so I'm sorry if I went about it wrong! (Specifically for Fantasy Crops, should have mentioned that.)