### PR TITLE
Fix broken reference to Poblano Extract in Artisan Valley

### DIFF
--- a/[PPJA] Artisan Valley/[DGA] Artisan Valley Machine Goods/machine-recipes.json
+++ b/[PPJA] Artisan Valley/[DGA] Artisan Valley Machine Goods/machine-recipes.json
@@ -2139,7 +2139,7 @@
         }, ],
         "Result":
         {
-            "Value": "ppja.artisanvalleymachinegoods.DGA/Poblano Chili Extract"
+            "Value": "ppja.artisanvalleymachinegoods.DGA/Poblano Extract"
         },
         "MachineWorkingTextureOverride": "Pepper Blender.png:1@10, Pepper Blender.png:2@10, Pepper Blender.png:3@10, Pepper Blender.png:4@10, Pepper Blender.png:5@10, Pepper Blender.png:6@10",
         "MachineFinishedTextureOverride": "assets/big-craftables/Pepper Blender.png:7",


### PR DESCRIPTION
The Pepper Blender was referencing "Poblano Chili Extract" which does not exist. Presumably it meant to referene "Poblano Extract" which does in fact exist and is currently unobtainable (despite being required for full shipment).